### PR TITLE
Bugfix/update mobile empty books list UI

### DIFF
--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/list/BooksEmptyListMessage.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/list/BooksEmptyListMessage.kt
@@ -6,7 +6,6 @@ package dev.marlonlom.itbooks.features.books.list
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/list/BooksEmptyListMessage.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/list/BooksEmptyListMessage.kt
@@ -40,8 +40,7 @@ internal fun BooksEmptyListMessage() = Column(modifier = Modifier.fillMaxSize())
   )
   Column(
     modifier = Modifier
-      .background(MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.25f), MaterialTheme.shapes.large)
-      .border(1.dp, MaterialTheme.colorScheme.error, MaterialTheme.shapes.large)
+      .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.25f), MaterialTheme.shapes.large)
       .padding(vertical = 20.dp),
     verticalArrangement = Arrangement.Center,
     horizontalAlignment = Alignment.CenterHorizontally,
@@ -69,7 +68,7 @@ internal fun BooksEmptyListMessage() = Column(modifier = Modifier.fillMaxSize())
         .padding(top = 20.dp),
       textAlign = TextAlign.Center,
       fontWeight = FontWeight.Bold,
-      color = MaterialTheme.colorScheme.onErrorContainer,
+      color = MaterialTheme.colorScheme.onSurface,
       text = annotatedString,
     )
   }


### PR DESCRIPTION
# Pull request details
Fix the background colors for empty books list ui slot, in `:apps:mobile` app module.