### PR TITLE
Feature/handle mobile app book details back navigation button visibility

### DIFF
--- a/apps/mobile/src/androidTest/kotlin/dev/marlonlom/itbooks/features/books/detail/screens/BookDetailsNormalContentUiTest.kt
+++ b/apps/mobile/src/androidTest/kotlin/dev/marlonlom/itbooks/features/books/detail/screens/BookDetailsNormalContentUiTest.kt
@@ -26,6 +26,7 @@ internal class BookDetailsNormalContentUiTest {
       setContent {
         BookDetailsNormalContent(
           uiStateProvider = { BookDetailsUiState.None },
+          isBackButtonVisible = { true },
           onBack = {},
           onBuy = {},
           onShare = {},
@@ -42,6 +43,7 @@ internal class BookDetailsNormalContentUiTest {
       setContent {
         BookDetailsNormalContent(
           uiStateProvider = { BookDetailsUiState.Loading },
+          isBackButtonVisible = { true },
           onBack = {},
           onBuy = {},
           onShare = {},

--- a/apps/mobile/src/androidTest/kotlin/dev/marlonlom/itbooks/features/books/detail/widgets/BookDetailsHeaderUiTest.kt
+++ b/apps/mobile/src/androidTest/kotlin/dev/marlonlom/itbooks/features/books/detail/widgets/BookDetailsHeaderUiTest.kt
@@ -30,6 +30,7 @@ internal class BookDetailsHeaderUiTest {
       setContent {
         BookDetailsHeader(
           bookIsbn13 = { bookIsbn13 },
+          isBackButtonVisible = { true },
           onBack = {
             backButtonClicked = true
           },

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/detail/BookDetailsScreenPane.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/detail/BookDetailsScreenPane.kt
@@ -22,6 +22,7 @@ import org.koin.androidx.compose.koinViewModel
  *
  * @param bookItem Book navigation item.
  * @param listPaneAdaptedValue Book details pane adapted value.
+ * @param isBackButtonVisible Action for checking if back navigation button should be visible.
  * @param onBack Action for back navigation.
  * @param onBuy Action for buying a book by its isbn13.
  * @param onShare Action for sharing a book by its isbn13.
@@ -33,6 +34,7 @@ import org.koin.androidx.compose.koinViewModel
 fun BookDetailsScreenPane(
   bookItem: ItBookNavigationItem?,
   listPaneAdaptedValue: PaneAdaptedValue,
+  isBackButtonVisible: () -> Boolean,
   onBack: () -> Unit,
   onBuy: (String) -> Unit,
   onShare: (String) -> Unit,
@@ -47,6 +49,7 @@ fun BookDetailsScreenPane(
     PaneAdaptedValue.Hidden -> {
       BookDetailsNormalContent(
         uiStateProvider = { uiState },
+        isBackButtonVisible = isBackButtonVisible,
         onBack = onBack,
         onBuy = onBuy,
         onShare = onShare,
@@ -57,6 +60,7 @@ fun BookDetailsScreenPane(
     PaneAdaptedValue.Expanded -> {
       BookDetailsExpandedContent(
         uiStateProvider = { uiState },
+        isBackButtonVisible = isBackButtonVisible,
         onBack = onBack,
         onBuy = onBuy,
         onShare = onShare,

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/detail/screens/BookDetailsExpandedContent.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/detail/screens/BookDetailsExpandedContent.kt
@@ -20,6 +20,7 @@ import dev.marlonlom.itbooks.features.books.detail.BookDetailsUiState
  * @author marlonlom
  *
  * @param uiStateProvider Action that returns book details ui state.
+ * @param isBackButtonVisible Action for checking if back navigation button should be visible.
  * @param onBack Action for back navigation.
  * @param onBuy Action for buying a book by its isbn13.
  * @param onShare Action for sharing a book by its isbn13.
@@ -27,6 +28,7 @@ import dev.marlonlom.itbooks.features.books.detail.BookDetailsUiState
 @Composable
 internal fun BookDetailsExpandedContent(
   uiStateProvider: () -> BookDetailsUiState,
+  isBackButtonVisible: () -> Boolean,
   onBack: () -> Unit,
   onBuy: (String) -> Unit,
   onShare: (String) -> Unit,
@@ -42,6 +44,7 @@ internal fun BookDetailsExpandedContent(
   ) {
     BookDetailsNormalContent(
       uiStateProvider = uiStateProvider,
+      isBackButtonVisible = isBackButtonVisible,
       onBack = onBack,
       onBuy = onBuy,
       onShare = onShare,

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/detail/screens/BookDetailsNormalContent.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/detail/screens/BookDetailsNormalContent.kt
@@ -38,6 +38,7 @@ import dev.marlonlom.itbooks.features.books.detail.widgets.BookDetailsHeader
  * @author marlonlom
  *
  * @param uiStateProvider Action that returns book details ui state.
+ * @param isBackButtonVisible Action for checking if back navigation button should be visible.
  * @param onBack Action for back navigation.
  * @param onBuy Action for buying a book by its isbn13.
  * @param onShare Action for sharing a book by its isbn13.
@@ -48,6 +49,7 @@ import dev.marlonlom.itbooks.features.books.detail.widgets.BookDetailsHeader
 @Composable
 internal fun BookDetailsNormalContent(
   uiStateProvider: () -> BookDetailsUiState,
+  isBackButtonVisible: () -> Boolean,
   onBack: () -> Unit,
   onBuy: (String) -> Unit,
   onShare: (String) -> Unit,
@@ -68,6 +70,7 @@ internal fun BookDetailsNormalContent(
             else -> ""
           }
         },
+        isBackButtonVisible = isBackButtonVisible,
         onBack = onBack,
         onBuy = onBuy,
         onShare = onShare,

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/detail/widgets/BookDetailsHeader.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/features/books/detail/widgets/BookDetailsHeader.kt
@@ -30,6 +30,7 @@ import dev.marlonlom.itbooks.R
  * @author marlonlom
  *
  * @param bookIsbn13 Action for getting book isbn13.
+ * @param isBackButtonVisible Action for checking if back navigation button should be visible.
  * @param onBack Action for back navigation.
  * @param onBuy Action for buying a book by its isbn13.
  * @param onShare Action for sharing a book by its isbn13.
@@ -37,6 +38,7 @@ import dev.marlonlom.itbooks.R
 @Composable
 internal fun BookDetailsHeader(
   bookIsbn13: () -> String,
+  isBackButtonVisible: () -> Boolean,
   onBack: () -> Unit,
   onBuy: (String) -> Unit,
   onShare: (String) -> Unit,
@@ -50,15 +52,17 @@ internal fun BookDetailsHeader(
       .background(rowBackground)
       .padding(bottom = 4.dp),
   ) {
-    IconButton(
-      modifier = Modifier.testTag("book_detail_back_btn"),
-      onClick = { onBack() },
-    ) {
-      Icon(
-        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
-        tint = MaterialTheme.colorScheme.secondary,
-        contentDescription = null,
-      )
+    if (isBackButtonVisible()) {
+      IconButton(
+        modifier = Modifier.testTag("book_detail_back_btn"),
+        onClick = { onBack() },
+      ) {
+        Icon(
+          imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+          tint = MaterialTheme.colorScheme.secondary,
+          contentDescription = null,
+        )
+      }
     }
     Spacer(Modifier.weight(1f))
     if (bookIsbn13Found.isNotEmpty()) {

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/scaffold/AppScaffold.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/scaffold/AppScaffold.kt
@@ -14,11 +14,11 @@ import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import dev.marlonlom.itbooks.features.books.detail.BookDetailsScreenPane
 import dev.marlonlom.itbooks.features.books.list.BooksListScreen
 import kotlinx.coroutines.launch
@@ -48,7 +48,7 @@ fun AppScaffold() {
     directive = navigator.scaffoldDirective,
     value = navigator.scaffoldValue,
     listPane = {
-      AnimatedPane(modifier = Modifier.preferredWidth(300.dp)) {
+      AnimatedPane {
         BooksListScreen(
           settingsIconClicked = {
             Log.d("AppScaffold", "Settings icon clicked.")
@@ -69,6 +69,10 @@ fun AppScaffold() {
         BookDetailsScreenPane(
           bookItem = navigator.currentDestination?.contentKey,
           listPaneAdaptedValue = navigator.scaffoldValue.secondary,
+          isBackButtonVisible = {
+            navigator.scaffoldValue.primary.equals(PaneAdaptedValue.Expanded)
+              .and(navigator.scaffoldValue.secondary.equals(PaneAdaptedValue.Hidden))
+          },
           onBack = {
             if (navigator.canNavigateBack()) {
               coroutineScope.launch {


### PR DESCRIPTION
# Pull request detail
Update book detail feature in mobile app module apps:mobile, changing the visibility of the back navigation button in the scenario where mobile device is displaying the list and detail screen panes at the same time.

Details:
- Handle back navigation button in book details screen feature.
- Update android ui tests after andling back navigation button in book details screen feature.