### PR TITLE
Integrate preferences repository in main activity, inside mobile app module 

### DIFF
--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/main/MainActivity.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/main/MainActivity.kt
@@ -8,8 +8,15 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import dev.marlonlom.itbooks.ui.scaffold.AppScaffold
-import dev.marlonlom.itbooks.ui.theme.ITBooksTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.compose.KoinContext
 
@@ -25,12 +32,19 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    var mainActivityUiState: MainActivityUiState by mutableStateOf(MainActivityUiState.Loading)
+
+    lifecycleScope.launch {
+      lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        mainActivityViewModel.uiState.onEach { mainActivityUiState = it }.collect()
+      }
+    }
+
     enableEdgeToEdge()
     setContent {
-      ITBooksTheme {
-        KoinContext {
-          AppScaffold()
-        }
+      KoinContext {
+        MainContent(mainActivityUiState)
       }
     }
   }

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/main/MainActivityUiState.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/main/MainActivityUiState.kt
@@ -4,6 +4,8 @@
  */
 package dev.marlonlom.itbooks.ui.main
 
+import dev.marlonlom.itbooks.core.preferences.UserPreferences
+
 /**
  * Main activity ui state data class.
  *
@@ -24,6 +26,7 @@ sealed interface MainActivityUiState {
    *
    * @author marlonlom
    *
+   * @property userPreferences User preferences data.
    */
-  data object Success : MainActivityUiState
+  data class Success(val userPreferences: UserPreferences) : MainActivityUiState
 }

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/main/MainActivityViewModel.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/main/MainActivityViewModel.kt
@@ -6,10 +6,11 @@ package dev.marlonlom.itbooks.ui.main
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dev.marlonlom.itbooks.core.preferences.PreferencesRepository
 import dev.marlonlom.itbooks.ui.main.MainActivityUiState.Loading
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 /**
@@ -17,13 +18,16 @@ import kotlinx.coroutines.flow.stateIn
  *
  * @author marlonlom
  *
+ * @property repository Preferences repository dependency.
  */
-class MainActivityViewModel : ViewModel() {
+class MainActivityViewModel(private val repository: PreferencesRepository) : ViewModel() {
 
   /** Main viewmodel ui state */
-  val uiState: StateFlow<MainActivityUiState> = flowOf(Loading).stateIn(
-    scope = viewModelScope,
-    initialValue = Loading,
-    started = SharingStarted.WhileSubscribed(5_000),
-  )
+  val uiState: StateFlow<MainActivityUiState> = repository.settingsFlow
+    .map { MainActivityUiState.Success(it) }
+    .stateIn(
+      scope = viewModelScope,
+      started = SharingStarted.WhileSubscribed(5_000),
+      initialValue = Loading,
+    )
 }

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/main/MainContent.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/main/MainContent.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.itbooks.ui.main
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import dev.marlonlom.itbooks.core.preferences.UserColorContrasts
+import dev.marlonlom.itbooks.ui.scaffold.AppScaffold
+import dev.marlonlom.itbooks.ui.theme.ITBooksTheme
+
+/**
+ * Main app content composable.
+ *
+ * @author marlonlom
+ *
+ * @param mainActivityUiState Main activity ui state.
+ */
+@Composable
+internal fun MainContent(mainActivityUiState: MainActivityUiState) = ITBooksTheme(
+  darkTheme = shouldUseDarkTheme(mainActivityUiState),
+  dynamicColor = shouldUseDynamicColor(mainActivityUiState),
+  colorContrast = shouldUseColorContrast(mainActivityUiState),
+) {
+  AppScaffold()
+}
+
+/**
+ * Returns true/false if dynamic colors are applied to the ui.
+ *
+ * @param mainActivityUiState Main activity ui state.
+ * @return true/false
+ */
+@Composable
+private fun shouldUseDynamicColor(mainActivityUiState: MainActivityUiState): Boolean = when (mainActivityUiState) {
+  MainActivityUiState.Loading -> false
+  is MainActivityUiState.Success -> mainActivityUiState.userPreferences.useDynamicColors
+}
+
+/**
+ * Returns true/false if dark theme is applied to the ui.
+ *
+ * @param mainActivityUiState Main activity ui state.
+ * @return true/false
+ */
+@Composable
+private fun shouldUseDarkTheme(mainActivityUiState: MainActivityUiState): Boolean = when (mainActivityUiState) {
+  MainActivityUiState.Loading -> isSystemInDarkTheme()
+  is MainActivityUiState.Success -> {
+    val useDarkTheme = mainActivityUiState.userPreferences.useDarkTheme
+    if (useDarkTheme.not()) isSystemInDarkTheme() else useDarkTheme
+  }
+}
+
+/**
+ * Returns the color contrast applied to the ui.
+ *
+ * @param mainActivityUiState Main activity ui state.
+ * @return Color contrast name.
+ */
+@Composable
+private fun shouldUseColorContrast(mainActivityUiState: MainActivityUiState): String = when (mainActivityUiState) {
+  MainActivityUiState.Loading -> UserColorContrasts.STANDARD.name
+  is MainActivityUiState.Success -> mainActivityUiState.userPreferences.colorContrast
+}


### PR DESCRIPTION
# Pull request detail
Integrate preferences repository in main activity, inside mobile app module `:apps:mobile`. 

- Integrate preferences repository into main activity viewmodel.
- Update main activity ui state.
- Implement main content composable.
- Implement functions that provides dark theme usage flag, dynamic colors usage flag and current color contrast from user preferences data from success main activity ui state.,
- Update main activity