### PR TITLE
Add chrome custom tabs opener utility in mobile app module 

### DIFF
--- a/apps/mobile/build.gradle.kts
+++ b/apps/mobile/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   implementation(project(":features:core:preferences"))
 
   implementation(libs.androidx.activity.compose)
+  implementation(libs.androidx.browser)
   implementation(libs.androidx.core.ktx)
   implementation(libs.androidx.lifecycle.runtime.ktx)
   implementation(libs.androidx.material3)

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/scaffold/AppScaffold.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/scaffold/AppScaffold.kt
@@ -19,8 +19,10 @@ import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaf
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import dev.marlonlom.itbooks.features.books.detail.BookDetailsScreenPane
 import dev.marlonlom.itbooks.features.books.list.BooksListScreen
+import dev.marlonlom.itbooks.ui.util.CustomTabsOpener
 import kotlinx.coroutines.launch
 
 /**
@@ -33,6 +35,7 @@ import kotlinx.coroutines.launch
 fun AppScaffold() {
   val navigator = rememberListDetailPaneScaffoldNavigator<ItBookNavigationItem>()
   val coroutineScope = rememberCoroutineScope()
+  val context = LocalContext.current
 
   BackHandler(navigator.canNavigateBack()) {
     coroutineScope.launch {
@@ -81,13 +84,13 @@ fun AppScaffold() {
             }
           },
           onBuy = {
-            Log.d("AppScaffold", "Buy book, url($it)")
+            CustomTabsOpener.openUrl(context, it)
           },
           onShare = {
             Log.d("AppScaffold", "Share book, msg($it)")
           },
           onReadMore = {
-            Log.d("AppScaffold", "Read more, url($it)")
+            CustomTabsOpener.openUrl(context, it)
           },
         )
       }

--- a/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/util/CustomTabsOpener.kt
+++ b/apps/mobile/src/main/kotlin/dev/marlonlom/itbooks/ui/util/CustomTabsOpener.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Marlonlom
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package dev.marlonlom.itbooks.ui.util
+
+import android.content.Context
+import android.content.Intent
+import androidx.browser.customtabs.CustomTabColorSchemeParams
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
+
+/**
+ * Chrome custom tabs opener single object utility.
+ *
+ * @author marlonlom
+ */
+object CustomTabsOpener {
+
+  private val customTabsIntent = CustomTabsIntent.Builder()
+    .setShowTitle(true)
+    .setInstantAppsEnabled(true)
+    .setDefaultColorSchemeParams(
+      CustomTabColorSchemeParams.Builder().build(),
+    ).build().apply {
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+
+  /**
+   * Opens an url as a custom tab.
+   *
+   * @param context Application context.
+   * @param url External url.
+   */
+  fun openUrl(context: Context, url: String) {
+    customTabsIntent.launchUrl(context, url.toUri())
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ spotless = "7.0.2"
 [libraries]
 # implementation
 androidx-activity-compose = "androidx.activity:activity-compose:1.10.1"
+androidx-browser = "androidx.browser:browser:1.8.0"
 androidx-core-ktx = "androidx.core:core-ktx:1.15.0"
 androidx-datastore-preferences = "androidx.datastore:datastore-preferences:1.1.3"
 androidx-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.8.7"


### PR DESCRIPTION
# Pull request detail
Add chrome custom tabs opener utility in mobile app module :apps:mobile.

- Update version catalog, adding androidx.browser library.
- Implement chrome custom tabs opener utility.
- Integrate the chrome custom tabs opener utility in mobile app scaffold.